### PR TITLE
Fix crash when opening process statistics

### DIFF
--- a/Dutch/main/Settings.apk/res/values-nl/strings.xml
+++ b/Dutch/main/Settings.apk/res/values-nl/strings.xml
@@ -2427,7 +2427,7 @@ Selecteer het OS van uw computer:"</string>
   <string name="process_stats_run_time">Uitvoeringstijd</string>
   <string name="process_stats_summary">Statistieken voor nerds over actieve processen</string>
   <string name="process_stats_summary_title">Processtatistieken</string>
-  <string name="process_stats_total_duration">%1$s van %2$s gebruikt over de laatste %3$s</string>
+  <string name="process_stats_total_duration">Apps (%1$s) in de laatste %2$s</string>
   <string name="process_stats_total_duration_percentage">%1$s RAM gebruikt in de laatste %2$s</string>
   <string name="process_stats_type_background">Achtergrond</string>
   <string name="process_stats_type_cached">In cache</string>


### PR DESCRIPTION
Commit 4c53a46135b4cb09b44a9e278a64d427583e1ba seems to have broken the
process statistics again.
